### PR TITLE
revert deploySig.js

### DIFF
--- a/src/deploySig.js
+++ b/src/deploySig.js
@@ -70,7 +70,7 @@ export function sign(keyHex, info) {
 
   return {
     data: {
-      Base16.encode(term),
+      term,
       timestamp,
       phloPrice,
       phloLimit,


### PR DESCRIPTION
the whole deploy needs to be hex, not just the term. We still need to find where the change needs to be made.